### PR TITLE
Allow polls to be tracked and exported by channel.

### DIFF
--- a/lib/lita/handlers/panic.rb
+++ b/lib/lita/handlers/panic.rb
@@ -52,9 +52,7 @@ module Lita
         poll.record user: msg.user, response: msg.message.body
         msg.reply_privately "Roger, thanks for the feedback"
 
-        if poll.complete?
-          robot.send_message Source.new(user: poll.poster), "The results are in"
-        end
+        notify_poster_of_complete_poll(poll) if poll.complete?
 
         score = msg.match_data[:score].to_i
         if score > 4
@@ -80,6 +78,15 @@ module Lita
         users.reject do |user|
           without_members_of.any? {|group| Lita::Authorization.new(config).user_in_group?(user, group)}
         end
+      end
+
+      def notify_poster_of_complete_poll(poll)
+        msg =  "The results are in for <#{poll.channel.id}|#{poll.channel.name}>\n"
+        msg += poll.user_responses.map do |(user, response)|
+          "<@#{user.id}|#{user.name}>: #{response}"
+        end.join("\n")
+
+        robot.send_message Source.new(user: poll.poster), msg
       end
 
       def channel_by msg

--- a/lib/lita/handlers/panic.rb
+++ b/lib/lita/handlers/panic.rb
@@ -74,12 +74,11 @@ module Lita
 
       private
 
-      def pollable_users_for_room(channel)
+      def pollable_users_for_room(channel, without_members_of: ['staff'])
         users = robot.roster(channel).map { |user_id| Lita::User.find_by_id user_id }
 
         users.reject do |user|
-          Lita::Authorization.new(config).user_in_group?(user, 'staff') || \
-          Lita::Authorization.new(config).user_in_group?(user, 'instructors')
+          without_members_of.any? {|group| Lita::Authorization.new(config).user_in_group?(user, group)}
         end
       end
 

--- a/lib/lita/handlers/panic.rb
+++ b/lib/lita/handlers/panic.rb
@@ -14,17 +14,19 @@ module Lita
         :answer,
         command: true
       route \
-        /panic export/,
+        /panic export\s*(\#([\.\w-]+))?/i,
         :export,
         command: true,
         restrict_to: [:instructors, :staff],
-        help: { "panic export" => "get a CSV dump of panic scores" }
+        help: { "panic export (#room)" => "get a CSV dump of panic scores" }
 
-      http.get "/panic/:token" do |request, response|
+      http.get "/panic/:token(/:channel)" do |request, response|
         token = request.env["router.params"][:token]
+        channel = request.env["router.params"][:channel]
+
         user  = Lita::Panic::Store.user_from_token token, redis: redis
         if user
-          response.body << Lita::Panic::Store.to_csv(redis: redis)
+          response.body << Lita::Panic::Store.to_csv(redis: redis, channel: channel)
         else
           response.status = 403
         end
@@ -34,14 +36,10 @@ module Lita
       def poll msg
         msg.reply "I don't know. I'll ask them."
 
-        channel = if name = msg.matches[0][1]
-          Lita::Room.find_by_name name
-        else
-          msg.room
-        end
+        channel = channel_by(msg) {|m| m.matches[0][1]}
 
         responders = robot.roster(channel).map { |user_id| Lita::User.find_by_id user_id }
-        Lita::Panic::Poll.create poster: msg.user, responders: responders, redis: redis
+        Lita::Panic::Poll.create poster: msg.user, responders: responders, redis: redis, channel: channel
         responders.each { |user| ping_with_poll user, msg }
       end
 
@@ -65,14 +63,22 @@ module Lita
         end
       end
 
-
       def export msg
         token = Lita::Panic::Store.export_token_for(msg.user, redis: redis)
-        msg.reply_privately "#{config.hostname}/panic/#{token}"
+        room = msg.matches[0][0]
+        path_component = room ? "/#{URI.encode room}" : nil
+        msg.reply_privately "#{config.hostname}/panic/#{token}#{path_component}"
       end
 
-
       private
+
+      def channel_by msg
+        if name = yield(msg)
+          Lita::Room.find_by_name name
+        else
+          msg.room
+        end
+      end
 
       def ping_with_poll user, response
         return if user.mention_name == robot.mention_name

--- a/lib/lita/panic/poll.rb
+++ b/lib/lita/panic/poll.rb
@@ -19,7 +19,7 @@ module Lita::Panic
 
     def initialize key:, redis:
       @key, @redis = key, redis
-      pref, @channel, @poster_id, @at = key.split ":"
+      pref, @channel_id, @poster_id, @at = key.split ":"
 
       raise "Invalid poll key: #{key}" unless pref == "poll"
     end
@@ -27,6 +27,10 @@ module Lita::Panic
     # The user who asked the inital question.
     def poster
       @_poster ||= Lita::User.find_by_id(poster_id)
+    end
+
+    def channel
+      @_channel ||= Lita::Room.find_by_name(channel_id)
     end
 
     def created_at
@@ -46,6 +50,12 @@ module Lita::Panic
       @_to_h ||= redis.hgetall(key).freeze
     end
 
+    def user_responses
+      @_user_responses ||= to_h.each_with_object({}) do |(user_id, value), resp|
+        resp[Lita::User.find_by_id(user_id)] = value
+      end
+    end
+
     def responder_ids
       redis.hkeys key
     end
@@ -56,6 +66,6 @@ module Lita::Panic
 
     private
 
-    attr_reader :key, :redis, :poster_id, :at
+    attr_reader :key, :redis, :poster_id, :channel_id, :at
   end
 end

--- a/lib/lita/panic/poll.rb
+++ b/lib/lita/panic/poll.rb
@@ -1,10 +1,10 @@
 module Lita::Panic
   class Poll
     class << self
-      def create poster:, responders:, redis:
+      def create poster:, responders:, redis:, channel:
         start    = Time.now.to_f
         finish   = start.to_i + 12 * 60 * 60
-        poll_key = "poll:#{poster.id}:#{start}"
+        poll_key = "poll:#{channel.id}:#{poster.id}:#{start}"
 
         values = responders.map { |r| [r.id, ""] }.flatten
         redis.hmset poll_key, *values
@@ -19,10 +19,12 @@ module Lita::Panic
 
     def initialize key:, redis:
       @key, @redis = key, redis
-      pref, @poster_id, @at = key.split ":"
+      pref, @channel, @poster_id, @at = key.split ":"
+
       raise "Invalid poll key: #{key}" unless pref == "poll"
     end
 
+    # The user who asked the inital question.
     def poster
       @_poster ||= Lita::User.find_by_id(poster_id)
     end

--- a/lib/lita/panic/store.rb
+++ b/lib/lita/panic/store.rb
@@ -17,9 +17,9 @@ module Lita::Panic
         tokens.keys.find { |user_id| tokens[user_id] == token }
       end
 
-      def to_csv redis:
+      def to_csv redis:, channel: nil
         polls = redis.keys.
-                select  { |k| k.start_with?("poll:") }.
+                select  { |k| k.start_with?("poll:#{channel}") }.
                 map     { |k| Poll.new key: k, redis: redis }.
                 sort_by { |p| p.created_at }
 

--- a/spec/lita/handlers/panic_spec.rb
+++ b/spec/lita/handlers/panic_spec.rb
@@ -26,7 +26,7 @@ describe Lita::Handlers::Panic, lita_handler: true do
       end
 
       it "asks everyony how they are doing" do
-        expect(replies.size).to eq 3
+        expect(replies.size).to eq 2
         expect(replies.first).to eq "I don't know. I'll ask them."
         expect(replies.last).to eq "Hey, how are you doing (on a scale of 1 (boredom) to 6 (panic))?"
       end
@@ -110,7 +110,7 @@ describe Lita::Handlers::Panic, lita_handler: true do
       it "will respond with other errors" do
         allow(robot).to receive(:send_message).twice.and_raise("BOOM")
         send_command("how is everyone doing?", as: lilly, from: Lita::Room.create_or_update("#lita.io"))
-        expect(replies.size).to eq 3
+        expect(replies.size).to eq 2
         expect(replies.first).to eq "I don't know. I'll ask them."
         expect(replies.last).to match /Shoot, I couldn't reach \w+ because we hit this bug `BOOM`/
       end

--- a/spec/lita/handlers/panic_spec.rb
+++ b/spec/lita/handlers/panic_spec.rb
@@ -14,7 +14,7 @@ describe Lita::Handlers::Panic, lita_handler: true do
   it { should_not route_command("This is a response with no numbers") }
 
   describe "#poll" do
-    let(:roster) { [lilly, bob].map &:id }
+    let(:roster) { [lilly, bob].map(&:id) }
 
     before do
       allow(robot).to receive(:roster).and_return(roster)
@@ -47,7 +47,7 @@ describe Lita::Handlers::Panic, lita_handler: true do
       end
 
       describe "with a larger class" do
-        let(:roster) { [lilly, bob, joe].map &:id }
+        let(:roster) { [lilly, bob, joe].map(&:id) }
 
         it "notifies the poller once everyone has responded" do
           expect { send_command("3", as: joe) }.not_to change { replies_to(lilly).count }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   end
 
-  config.profile_examples = ENV.fetch("RSPEC_PROFILE_COUNT", 10).to_i
+  # config.profile_examples = ENV.fetch("RSPEC_PROFILE_COUNT", 10).to_i
   config.order = :random
   Kernel.srand config.seed
 end


### PR DESCRIPTION
As a more classes have used this the data stored is more difficult to extract into meaningful reports. This allows for room specific exports for easier charting.
For backwards compatibility you can still do a full export of all rooms.
